### PR TITLE
replace merge-queue with main

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   test:
-    uses: cloudposse-terraform-components/.github/.github/workflows/shared-terraform-chatops.yml@merge-queue
+    uses: cloudposse-terraform-components/.github/.github/workflows/shared-terraform-chatops.yml@main
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/terratest') }}
     secrets: inherit

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   scheduled:
-    uses: cloudposse-terraform-components/.github/.github/workflows/shared-terraform-scheduled.yml@merge-queue
+    uses: cloudposse-terraform-components/.github/.github/workflows/shared-terraform-scheduled.yml@main
     secrets: inherit


### PR DESCRIPTION
This pull request updates the workflow references in the repository to point to the `main` branch instead of the `merge-queue` branch. This ensures that the workflows use the latest stable version of the shared configurations.

Workflow updates:

* [`.github/workflows/chatops.yml`](diffhunk://#diff-1826ae959b08208213645307116e334bb2cff715af39ba440754519e76668fa9L15-R15): Updated the `uses` reference to point to the `main` branch for the `shared-terraform-chatops.yml` workflow.
* [`.github/workflows/scheduled.yml`](diffhunk://#diff-f4109e225f86cb2508cacc3bd71f0782d0d42dd5caa207350bc8f72abbb18af3L15-R15): Updated the `uses` reference to point to the `main` branch for the `shared-terraform-scheduled.yml` workflow.