### PR TITLE
Use atmos instead of makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ aws-assumed-role/
 *.iml
 .direnv
 .envrc
+.atmos
 
 # Compiled and auto-generated files
 # Note that the leading "**/" appears necessary for Docker even if not for Git

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,0 @@
--include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
-
-all: init readme

--- a/README.yaml
+++ b/README.yaml
@@ -64,8 +64,7 @@ usage: |-
 
 
 
-include:
-  - "docs/terraform.md"
+include: []
 
 tags:
   - terraform

--- a/atmos.yaml
+++ b/atmos.yaml
@@ -1,0 +1,11 @@
+# Atmos Configuration — powered by https://atmos.tools
+#
+# This configuration enables centralized, DRY, and consistent project scaffolding using Atmos.
+#
+# Included features:
+# - Organizational custom commands: https://atmos.tools/core-concepts/custom-commands
+# - Automated README generation: https://atmos.tools/cli/commands/docs/generate
+#
+# Import shared configuration used by all modules
+import:
+  - https://raw.githubusercontent.com/cloudposse-terraform-components/.github/refs/heads/main/.github/atmos/terraform-component.yaml


### PR DESCRIPTION
## what
* Use atmos instead of makefile

## why
* build-harness deprecated. Use atmos instead 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a centralized configuration that imports shared settings for consistent behavior across modules.

* Chores
  * Updated ignore rules to exclude Atmos-related artifacts.
  * Removed remote build bootstrap and the default aggregate build task.

* Documentation
  * Stopped auto-including the Terraform documentation in the generated README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->